### PR TITLE
dev/core#2121 New field added in the pdf form for the filename

### DIFF
--- a/CRM/Contact/Form/Task/PDFLetterCommon.php
+++ b/CRM/Contact/Form/Task/PDFLetterCommon.php
@@ -178,8 +178,10 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $mimeType = self::getMimeType($type);
     // ^^ Useful side-effect: consistently throws error for unrecognized types.
 
+    $fileName = self::getFileName($form);
+    $fileName = "$fileName.$type";
+
     if ($type == 'pdf') {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Utils::html2pdf($html, $fileName, FALSE, $formValues);
     }
     elseif (!empty($formValues['document_file_path'])) {
@@ -187,7 +189,6 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
       CRM_Utils_PDF_Document::printDocuments($html, $fileName, $type, $zip);
     }
     else {
-      $fileName = "CiviLetter.$type";
       CRM_Utils_PDF_Document::html2doc($html, $fileName, $formValues);
     }
 
@@ -213,6 +214,29 @@ class CRM_Contact_Form_Task_PDFLetterCommon extends CRM_Core_Form_Task_PDFLetter
     $form->postProcessHook();
 
     CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * Returns the filename for the pdf by striping off unwanted characters and limits the length to 200 characters.
+   *
+   * @param CRM_Core_Form $form
+   *
+   * @return string
+   *   The name of the file.
+   */
+  private static function getFileName(CRM_Core_Form $form) {
+    if (!empty($form->getVar('_submitValues')['filename'])) {
+      $fileName = CRM_Utils_String::munge($form->getVar('_submitValues')['filename'], '_', 200);
+    }
+    elseif (!empty($form->getElement('subject')) && !empty($form->getElement('subject')->getValue())) {
+      $fileName = CRM_Utils_String::munge($form->getElement('subject')->getValue(), '_', 200);
+    }
+    else {
+      $fileName = "CiviLetter";
+    }
+    $fileName = self::isLiveMode($form) ? $fileName : $fileName . "_preview";
+
+    return $fileName;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This pr allows the user to provide any name of his choice for the downloading file while creating pdf documents.

Before
----------------------------------------
Any document that was created had a pre defined name of `CiviLetter.ext` and it was not customizable.

After
----------------------------------------
Now a new field has been added to the  form that is responsible for creating the pdf and user can provide any alphanumeric value in the field and that value will be used as a name for the file that will be downloaded once user clicks on download buttons. This pr also appends the filename with '_preview' if user is previewing the document instead of creating the document.